### PR TITLE
fix credential cache scope

### DIFF
--- a/services/ocrService.js
+++ b/services/ocrService.js
@@ -28,7 +28,7 @@ const MAX_POOL_SIZE = 20; // Increased for higher concurrency
 
 // Cache for credential files and their content
 let cachedCredentialFiles = null;
-const credentialContentCache = {}; // Cache credential file contents
+const credentialFileCache = {}; // Cache credential file contents
 
 // LRU Cache for authenticated clients
 const clientCache = new LRUCache({
@@ -143,12 +143,12 @@ async function getGoogleClient() {
     // Read the credential file - use cached content when available
     let credentials;
 
-    if (credentialContentCache[selectedCredentialPath]) {
-      credentials = credentialContentCache[selectedCredentialPath];
+    if (credentialFileCache[selectedCredentialPath]) {
+      credentials = credentialFileCache[selectedCredentialPath];
     } else {
       const credentialContent = await fs.readFile(selectedCredentialPath, "utf8");
       credentials = JSON.parse(credentialContent);
-      credentialContentCache[selectedCredentialPath] = credentials;
+      credentialFileCache[selectedCredentialPath] = credentials;
     }
 
     // Create and authorize client


### PR DESCRIPTION
## Summary
- expose `credentialFileCache` at module scope for reuse
- use shared credential cache in `getGoogleClient`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852dc3556488325a6cca471d4eb0363