### PR TITLE
Fix token request body formatting

### DIFF
--- a/services/directApiOcrService.js
+++ b/services/directApiOcrService.js
@@ -174,12 +174,14 @@ async function getAccessToken(credentials) {
     const jwt = await generateJWT(credentials);
     
     // Exchange JWT for access token
+    const params = new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: jwt,
+    });
+
     const response = await axios.post(
       'https://oauth2.googleapis.com/token',
-      {
-        grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
-        assertion: jwt
-      },
+      params.toString(),
       {
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded'


### PR DESCRIPTION
## Summary
- use `URLSearchParams` so the OAuth token request is truly URL encoded

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js` *(fails: Request to oauth2.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6852dc22591c83259dc9afd328140310